### PR TITLE
Change pointer when hover over a Route rule span

### DIFF
--- a/frontend/src/components/IstioWizards/K8sRequestRouting/K8sMatches.tsx
+++ b/frontend/src/components/IstioWizards/K8sRequestRouting/K8sMatches.tsx
@@ -13,10 +13,14 @@ const labelContainerStyle = style({
   height: 40
 });
 
+const remove = style({
+  cursor: "not-allowed"
+});
+
 class K8sMatches extends React.Component<Props> {
   render() {
     const matches: any[] = this.props.matches.map((match, index) => (
-      <span key={match + '-' + index} data-test={match}>
+      <span key={match + '-' + index} data-test={match} className={remove}>
         <Chip onClick={() => this.props.onRemoveMatch(match)} isOverflowChip={true}>
           {match}
         </Chip>{' '}


### PR DESCRIPTION
This is a proposal to make more explicit the actions in the span route rules changing the default cursor:

![image](https://user-images.githubusercontent.com/49480155/199973542-8644cf8b-74e6-43eb-a104-2aebed1d5ef8.png)
