### PR TITLE
Compatible links with OSSMC

### DIFF
--- a/frontend/src/pages/Overview/Links.ts
+++ b/frontend/src/pages/Overview/Links.ts
@@ -1,22 +1,19 @@
-import { FilterSelected } from '../../components/Filters/StatefulFilters';
-import { router, URLParam } from '../../app/History';
+import { URLParam } from '../../app/History';
 import { camelCase } from 'lodash';
 import { categoryFilter, healthFilter, NamespaceCategory } from '../Namespaces/Filters';
 import { Paths } from '../../config';
 import { HealthStatusId } from '../../types/Health';
+import { kialiNavigate } from '../../utils/NavigationUtils';
+import { FilterSelected } from '../../components/Filters/StatefulFilters';
 
 const typeFilterParam = camelCase(categoryFilter.category);
 const healthFilterParam = camelCase(healthFilter.category);
 const controlPlaneParamValue = NamespaceCategory.CONTROL_PLANE;
 const dataPlaneParamValue = NamespaceCategory.DATA_PLANE;
 
-export const handleViewAllClick = (): void => {
-  FilterSelected.resetFilters();
-};
-
 export const navigateToUrl = (url: string): void => {
-  handleViewAllClick();
-  router.navigate(url);
+  FilterSelected.resetFilters();
+  kialiNavigate(url);
 };
 
 export const buildDataPlanesUrl = (status?: HealthStatusId): string => {

--- a/frontend/src/utils/NavigationUtils.ts
+++ b/frontend/src/utils/NavigationUtils.ts
@@ -1,0 +1,23 @@
+import { router } from '../app/History';
+import { store } from '../store/ConfigStore';
+import { isParentKiosk, kioskContextMenuAction } from '../components/Kiosk/KioskActions';
+
+/**
+ * Navigate to a URL in a way that is compatible with both standalone Kiali
+ * and OSSMC (OpenShift Service Mesh Console) kiosk mode.
+ *
+ * When running in kiosk mode with a parent (OSSMC), this sends a postMessage
+ * to the parent window instead of using the router directly.
+ *
+ * @param url - The URL path to navigate to (e.g., '/namespaces' or '/mesh?meshHide=...')
+ * @param replace - If true, replaces the current history entry instead of pushing a new one
+ */
+export const kialiNavigate = (url: string, replace?: boolean): void => {
+  const kiosk = store.getState().globalState.kiosk;
+
+  if (isParentKiosk(kiosk)) {
+    kioskContextMenuAction(url);
+  } else {
+    router.navigate(url, { replace });
+  }
+};


### PR DESCRIPTION
### Describe the change

Make new Overview pages links compatible with OSSMC wrapping the router navigation into a new kialiNavigate utils method.

### Steps to test the PR

Links work as expected