### PR TITLE
Add test coverage

### DIFF
--- a/ai/mcp/manage_istio_config/istio_list.go
+++ b/ai/mcp/manage_istio_config/istio_list.go
@@ -20,21 +20,20 @@ import (
 )
 
 // defaultIstioConfigCriteria returns the criteria for listing Istio config objects.
-// When enableGatewayAPI is true (i.e. Gateway API CRDs are installed), Gateway API types (K8sGateways, K8sHTTPRoutes, etc.)
+// When isGatewayAPIEnabled is true (i.e. Gateway API CRDs are installed), Gateway API types (K8sGateways, K8sHTTPRoutes, etc.)
 // are included; otherwise they are excluded to avoid unnecessary API calls.
-// When enableInferenceAPI is true (i.e. inference.networking.k8s.io CRDs are installed),
+// When isInferenceAPIEnabled is true (i.e. inference.networking.k8s.io CRDs are installed),
 // InferencePool resources are included.
-func defaultIstioConfigCriteria(enableGatewayAPI bool, enableInferenceAPI ...bool) business.IstioConfigCriteria {
-	inferenceEnabled := len(enableInferenceAPI) > 0 && enableInferenceAPI[0]
+func defaultIstioConfigCriteria(isGatewayAPIEnabled bool, isInferenceAPIEnabled bool) business.IstioConfigCriteria {
 	return business.IstioConfigCriteria{
 		IncludeGateways:               true,
-		IncludeK8sGateways:            enableGatewayAPI,
-		IncludeK8sGRPCRoutes:          enableGatewayAPI,
-		IncludeK8sHTTPRoutes:          enableGatewayAPI,
-		IncludeK8sInferencePools:      inferenceEnabled,
-		IncludeK8sReferenceGrants:     enableGatewayAPI,
-		IncludeK8sTCPRoutes:           enableGatewayAPI,
-		IncludeK8sTLSRoutes:           enableGatewayAPI,
+		IncludeK8sGateways:            isGatewayAPIEnabled,
+		IncludeK8sGRPCRoutes:          isGatewayAPIEnabled,
+		IncludeK8sHTTPRoutes:          isGatewayAPIEnabled,
+		IncludeK8sInferencePools:      isInferenceAPIEnabled,
+		IncludeK8sReferenceGrants:     isGatewayAPIEnabled,
+		IncludeK8sTCPRoutes:           isGatewayAPIEnabled,
+		IncludeK8sTLSRoutes:           isGatewayAPIEnabled,
 		IncludeVirtualServices:        true,
 		IncludeDestinationRules:       true,
 		IncludeServiceEntries:         true,
@@ -88,7 +87,7 @@ type validationCheckSummary struct {
 	Message  string
 }
 
-func IstioList(ctx context.Context, args map[string]interface{}, businessLayer *business.Layer, conf *config.Config, enableGatewayAPI bool, enableInferenceAPI bool) (interface{}, int) {
+func IstioList(ctx context.Context, args map[string]interface{}, businessLayer *business.Layer, conf *config.Config, isGatewayAPIEnabled bool, isInferenceAPIEnabled bool) (interface{}, int) {
 	// Extract parameters
 	cluster := mcputil.GetStringArg(args, "clusterName")
 	namespace := mcputil.GetStringArg(args, "namespace")
@@ -102,12 +101,12 @@ func IstioList(ctx context.Context, args map[string]interface{}, businessLayer *
 		cluster = conf.KubernetesConfig.ClusterName
 	}
 
-	criteria := defaultIstioConfigCriteria(enableGatewayAPI, enableInferenceAPI)
+	criteria := defaultIstioConfigCriteria(isGatewayAPIEnabled, isInferenceAPIEnabled)
 	if kind != "" {
 		if group == "" {
-			group = inferGroupFromKind(kind, enableGatewayAPI, enableInferenceAPI)
+			group = inferGroupFromKind(kind, isGatewayAPIEnabled, isInferenceAPIEnabled)
 		}
-		criteria = criteriaForListFilter(group, kind, enableGatewayAPI, enableInferenceAPI)
+		criteria = criteriaForListFilter(group, kind, isGatewayAPIEnabled, isInferenceAPIEnabled)
 	}
 
 	if namespace == "" {
@@ -572,7 +571,7 @@ func filterGatewaysReferencedByVirtualServices(
 	return out, warnings
 }
 
-func criteriaForListFilter(group, kind string, enableGatewayAPI, enableInferenceAPI bool) business.IstioConfigCriteria {
+func criteriaForListFilter(group, kind string, isGatewayAPIEnabled, isInferenceAPIEnabled bool) business.IstioConfigCriteria {
 	// Default: if we can't confidently map it, keep original behavior.
 	c := business.IstioConfigCriteria{}
 
@@ -645,5 +644,5 @@ func criteriaForListFilter(group, kind string, enableGatewayAPI, enableInference
 		}
 	}
 
-	return defaultIstioConfigCriteria(enableGatewayAPI, enableInferenceAPI)
+	return defaultIstioConfigCriteria(isGatewayAPIEnabled, isInferenceAPIEnabled)
 }

--- a/ai/mcp/manage_istio_config/istio_list_test.go
+++ b/ai/mcp/manage_istio_config/istio_list_test.go
@@ -287,3 +287,59 @@ func TestIstioList_IncludesTrafficExtensions(t *testing.T) {
 	assert.Equal(t, "east", result.Cluster)
 	assert.Empty(t, result.Namespaces)
 }
+
+// TestIstioList_AllGatewaysReturnedWithoutServiceFilter
+// Gateways are only filtered to those referenced
+// by VirtualServices when a serviceName filter is active. Without a service
+// filter every Gateway in the namespace must be returned, even those not
+// referenced by any VirtualService.
+func TestIstioList_AllGatewaysReturnedWithoutServiceFilter(t *testing.T) {
+	conf := config.NewConfig()
+	conf.KubernetesConfig.ClusterName = "east"
+	config.Set(conf)
+
+	// A gateway that IS referenced by a VirtualService.
+	referencedGW := &networking_v1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Name: "referenced-gw", Namespace: "bookinfo"},
+		Spec:       istio_api_v1alpha3.Gateway{},
+	}
+
+	// A gateway that is NOT referenced by any VirtualService.
+	unreferencedGW := &networking_v1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Name: "unreferenced-gw", Namespace: "bookinfo"},
+		Spec:       istio_api_v1alpha3.Gateway{},
+	}
+
+	// VirtualService that points only to the first gateway.
+	vs := &networking_v1.VirtualService{
+		ObjectMeta: metav1.ObjectMeta{Name: "reviews-vs", Namespace: "bookinfo"},
+		Spec: istio_api_v1alpha3.VirtualService{
+			Hosts:    []string{"reviews"},
+			Gateways: []string{"referenced-gw"},
+		},
+	}
+
+	ns := &core_v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "bookinfo"}}
+	k8s := kubetest.NewFakeK8sClient(ns, referencedGW, unreferencedGW, vs)
+	businessLayer := business.NewLayerBuilder(t, conf).WithClient(k8s).Build()
+
+	args := map[string]interface{}{
+		"namespace": "bookinfo",
+	}
+
+	res, status := IstioList(context.Background(), args, businessLayer, conf, false, false)
+	require.Equal(t, http.StatusOK, status)
+
+	result, ok := res.(IstioListResult)
+	require.True(t, ok)
+	bookinfo := result.Namespaces["bookinfo"]
+	require.NotNil(t, bookinfo)
+
+	gwKey := "networking.istio.io/v1/Gateway"
+	gwEntry, ok := bookinfo[gwKey]
+	require.True(t, ok, "gateways should appear in the list result")
+
+	allGWNames := append(gwEntry.Valid, gwEntry.Invalid...)
+	assert.Contains(t, allGWNames, "referenced-gw")
+	assert.Contains(t, allGWNames, "unreferenced-gw", "unreferenced-gw must be returned when no service filter is applied")
+}

--- a/ai/mcp/manage_istio_config/manage_istio_config.go
+++ b/ai/mcp/manage_istio_config/manage_istio_config.go
@@ -29,9 +29,9 @@ func ExecuteReadOnly(kialiInterface *mcputil.KialiInterface, args map[string]int
 	action := mcputil.GetStringArg(args, "action")
 	namespace := mcputil.GetStringArg(args, "namespace")
 	clusterName := mcputil.GetStringOrDefault(args, kialiInterface.Conf.KubernetesConfig.ClusterName, "clusterName")
-	gwEnabled := isGatewayAPIEnabled(kialiInterface, clusterName)
-	inferenceEnabled := isInferenceAPIEnabled(kialiInterface, clusterName)
-	if err := validateReadOnlyIstioConfigInput(args, gwEnabled, inferenceEnabled); err != nil {
+	isGatewayAPIEnabled := isGatewayAPIEnabled(kialiInterface, clusterName)
+	isInferenceAPIEnabled := isInferenceAPIEnabled(kialiInterface, clusterName)
+	if err := validateReadOnlyIstioConfigInput(args, isGatewayAPIEnabled, isInferenceAPIEnabled); err != nil {
 		return err.Error(), http.StatusOK
 	}
 	if action != "list" {
@@ -57,7 +57,7 @@ func ExecuteReadOnly(kialiInterface *mcputil.KialiInterface, args map[string]int
 
 	switch action {
 	case "list":
-		return IstioList(kialiInterface.Request.Context(), args, kialiInterface.BusinessLayer, kialiInterface.Conf, gwEnabled, inferenceEnabled)
+		return IstioList(kialiInterface.Request.Context(), args, kialiInterface.BusinessLayer, kialiInterface.Conf, isGatewayAPIEnabled, isInferenceAPIEnabled)
 	case "get":
 		return IstioGet(kialiInterface.Request.Context(), args, kialiInterface.BusinessLayer, kialiInterface.Conf)
 	default:
@@ -70,13 +70,13 @@ func Execute(kialiInterface *mcputil.KialiInterface, args map[string]interface{}
 	confirmed := mcputil.AsBool(args["confirmed"])
 	mcpMode := mcputil.AsBoolOrDefault(args, false, "mcp_mode")
 	clusterName := mcputil.GetStringOrDefault(args, kialiInterface.Conf.KubernetesConfig.ClusterName, "clusterName")
-	gwEnabled := isGatewayAPIEnabled(kialiInterface, clusterName)
-	inferenceEnabled := isInferenceAPIEnabled(kialiInterface, clusterName)
+	isGatewayAPIEnabled := isGatewayAPIEnabled(kialiInterface, clusterName)
+	isInferenceAPIEnabled := isInferenceAPIEnabled(kialiInterface, clusterName)
 
 	if action == "list" || action == "get" {
 		return "for list and get actions use the manage_istio_config_read tool", http.StatusBadRequest
 	}
-	if err := validateIstioConfigInput(args, gwEnabled, inferenceEnabled); err != nil {
+	if err := validateIstioConfigInput(args, isGatewayAPIEnabled, isInferenceAPIEnabled); err != nil {
 		return err.Error(), http.StatusBadRequest
 	}
 
@@ -524,7 +524,7 @@ func fixInferencePoolSpec(data []byte) []byte {
 		spec["endpointPickerRef"] = map[string]interface{}{
 			"group":       "",
 			"kind":        "Service",
-			"name":        "example-epp",
+			"name":        "example-model-epp",
 			"port":        map[string]interface{}{"number": float64(9002)},
 			"failureMode": "FailClose",
 		}
@@ -698,11 +698,11 @@ var allowedInferenceAPIKinds = map[string]struct{}{
 // inferGroupFromKind attempts to resolve the API group from the kind alone.
 // Returns the group if the kind unambiguously belongs to one group, or "" if ambiguous
 // (e.g. "Gateway" exists in both networking.istio.io and gateway.networking.k8s.io).
-func inferGroupFromKind(kind string, gwEnabled, inferenceEnabled bool) string {
+func inferGroupFromKind(kind string, isGatewayAPIEnabled, isInferenceAPIEnabled bool) string {
 	if _, ok := allowedSecurityIstioKinds[kind]; ok {
 		return "security.istio.io"
 	}
-	if _, ok := allowedInferenceAPIKinds[kind]; ok && inferenceEnabled {
+	if _, ok := allowedInferenceAPIKinds[kind]; ok && isInferenceAPIEnabled {
 		return "inference.networking.k8s.io"
 	}
 	inNetworking := false
@@ -710,7 +710,7 @@ func inferGroupFromKind(kind string, gwEnabled, inferenceEnabled bool) string {
 		inNetworking = true
 	}
 	inGatewayAPI := false
-	if _, ok := allowedGatewayAPIKinds[kind]; ok && gwEnabled {
+	if _, ok := allowedGatewayAPIKinds[kind]; ok && isGatewayAPIEnabled {
 		inGatewayAPI = true
 	}
 	if inNetworking && !inGatewayAPI {
@@ -726,23 +726,23 @@ func inferGroupFromKind(kind string, gwEnabled, inferenceEnabled bool) string {
 // (when Gateway API is discovered) gateway.networking.k8s.io, or (when Inference API is
 // discovered) inference.networking.k8s.io, and kind is allowed for that group.
 // When group is empty but kind is unambiguous, the group is inferred automatically.
-// The variadic flags parameter accepts: [0] = enableGatewayAPI, [1] = enableInferenceAPI.
+// The variadic flags parameter accepts: [0] = isGatewayAPIEnabled, [1] = isInferenceAPIEnabled.
 func validateManagedIstioGroupAndKind(group, kind string, flags ...bool) error {
 	g := strings.TrimSpace(group)
 	k := strings.TrimSpace(kind)
-	gwEnabled := len(flags) > 0 && flags[0]
-	inferenceEnabled := len(flags) > 1 && flags[1]
+	isGatewayAPIEnabled := len(flags) > 0 && flags[0]
+	isInferenceAPIEnabled := len(flags) > 1 && flags[1]
 	if g == "" && k != "" {
-		if inferred := inferGroupFromKind(k, gwEnabled, inferenceEnabled); inferred != "" {
+		if inferred := inferGroupFromKind(k, isGatewayAPIEnabled, isInferenceAPIEnabled); inferred != "" {
 			g = inferred
 		}
 	}
 	if g == "" {
 		groups := []string{`"networking.istio.io"`, `"security.istio.io"`}
-		if gwEnabled {
+		if isGatewayAPIEnabled {
 			groups = append(groups, `"gateway.networking.k8s.io"`)
 		}
-		if inferenceEnabled {
+		if isInferenceAPIEnabled {
 			groups = append(groups, `"inference.networking.k8s.io"`)
 		}
 		return fmt.Errorf("group is required and must be %s", strings.Join(groups, ", "))
@@ -768,7 +768,7 @@ func validateManagedIstioGroupAndKind(group, kind string, flags ...bool) error {
 		}
 		return nil
 	case "gateway.networking.k8s.io":
-		if !gwEnabled {
+		if !isGatewayAPIEnabled {
 			return fmt.Errorf(`invalid group %q: Gateway API CRDs are not installed on the cluster`, g)
 		}
 		if _, ok := allowedGatewayAPIKinds[k]; !ok {
@@ -779,7 +779,7 @@ func validateManagedIstioGroupAndKind(group, kind string, flags ...bool) error {
 		}
 		return nil
 	case "inference.networking.k8s.io":
-		if !inferenceEnabled {
+		if !isInferenceAPIEnabled {
 			return fmt.Errorf(`invalid group %q: Inference API CRDs are not installed on the cluster`, g)
 		}
 		if _, ok := allowedInferenceAPIKinds[k]; !ok {
@@ -791,10 +791,10 @@ func validateManagedIstioGroupAndKind(group, kind string, flags ...bool) error {
 		return nil
 	default:
 		groups := []string{`"networking.istio.io"`, `"security.istio.io"`}
-		if gwEnabled {
+		if isGatewayAPIEnabled {
 			groups = append(groups, `"gateway.networking.k8s.io"`)
 		}
-		if inferenceEnabled {
+		if isInferenceAPIEnabled {
 			groups = append(groups, `"inference.networking.k8s.io"`)
 		}
 		return fmt.Errorf("invalid group %q: must be %s", g, strings.Join(groups, ", "))
@@ -863,7 +863,7 @@ func validateReadableGroupAndKind(group, kind string) error {
 }
 
 // validateReadOnlyIstioConfigInput validates args for read-only actions (list, get).
-// The variadic flags parameter accepts: [0] = enableGatewayAPI, [1] = enableInferenceAPI.
+// The variadic flags parameter accepts: [0] = isGatewayAPIEnabled, [1] = isInferenceAPIEnabled.
 func validateReadOnlyIstioConfigInput(args map[string]interface{}, flags ...bool) error {
 	action := mcputil.GetStringArg(args, "action")
 	namespace := mcputil.GetStringArg(args, "namespace")
@@ -879,9 +879,9 @@ func validateReadOnlyIstioConfigInput(args map[string]interface{}, flags ...bool
 			return nil
 		}
 		if hasKind && !hasGroup {
-			gwEnabled := len(flags) > 0 && flags[0]
-			inferenceEnabled := len(flags) > 1 && flags[1]
-			inferred := inferGroupFromKind(kind, gwEnabled, inferenceEnabled)
+			isGatewayAPIEnabled := len(flags) > 0 && flags[0]
+			isInferenceAPIEnabled := len(flags) > 1 && flags[1]
+			inferred := inferGroupFromKind(kind, isGatewayAPIEnabled, isInferenceAPIEnabled)
 			if inferred != "" {
 				return validateReadableGroupAndKind(inferred, kind)
 			}
@@ -917,7 +917,7 @@ func validateReadOnlyIstioConfigInput(args map[string]interface{}, flags ...bool
 // It also normalizes args: if "object" is missing it falls back to "name" or
 // extracts metadata.name from "data", writing the resolved value back into
 // args["object"] so downstream code sees it.
-// The variadic flags parameter accepts: [0] = enableGatewayAPI, [1] = enableInferenceAPI.
+// The variadic flags parameter accepts: [0] = isGatewayAPIEnabled, [1] = isInferenceAPIEnabled.
 func validateIstioConfigInput(args map[string]interface{}, flags ...bool) error {
 	action := mcputil.GetStringArg(args, "action")
 	namespace := mcputil.GetStringArg(args, "namespace")

--- a/ai/mcp/manage_istio_config/manage_istio_config_test.go
+++ b/ai/mcp/manage_istio_config/manage_istio_config_test.go
@@ -2036,8 +2036,8 @@ func TestValidateIstioConfigInput_GatewayAPIEnabled(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gwEnabled := !strings.Contains(tt.name, "rejected when disabled")
-			err := validateIstioConfigInput(tt.args, gwEnabled)
+			isGatewayAPIEnabled := !strings.Contains(tt.name, "rejected when disabled")
+			err := validateIstioConfigInput(tt.args, isGatewayAPIEnabled)
 			if tt.wantErr != "" {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.wantErr)
@@ -2165,7 +2165,7 @@ func TestFixHTTPRoutePathTypes(t *testing.T) {
 }
 
 func TestDefaultIstioConfigCriteria_GatewayAPIEnabled(t *testing.T) {
-	criteria := defaultIstioConfigCriteria(true)
+	criteria := defaultIstioConfigCriteria(true, false)
 	assert.True(t, criteria.IncludeK8sGateways)
 	assert.True(t, criteria.IncludeK8sHTTPRoutes)
 	assert.True(t, criteria.IncludeK8sGRPCRoutes)
@@ -2177,7 +2177,7 @@ func TestDefaultIstioConfigCriteria_GatewayAPIEnabled(t *testing.T) {
 }
 
 func TestDefaultIstioConfigCriteria_GatewayAPIDisabled(t *testing.T) {
-	criteria := defaultIstioConfigCriteria(false)
+	criteria := defaultIstioConfigCriteria(false, false)
 	assert.False(t, criteria.IncludeK8sGateways)
 	assert.False(t, criteria.IncludeK8sHTTPRoutes)
 	assert.False(t, criteria.IncludeK8sGRPCRoutes)
@@ -2300,4 +2300,202 @@ func TestBuildResourceTemplate_InferencePool(t *testing.T) {
 	assert.Equal(t, "Service", epr["kind"])
 	assert.Equal(t, "example-model-epp", epr["name"])
 	assert.Equal(t, "FailClose", epr["failureMode"])
+}
+
+// ---------------------------------------------------------------------------
+// fixHTTPRoutePathTypes unit tests
+// ---------------------------------------------------------------------------
+
+func TestFixHTTPRoutePathTypes_PrefixCorrected(t *testing.T) {
+	input := `{"spec":{"rules":[{"matches":[{"path":{"type":"Prefix","value":"/api"}}]}]}}`
+	output := fixHTTPRoutePathTypes([]byte(input))
+	var obj map[string]interface{}
+	require.NoError(t, json.Unmarshal(output, &obj))
+	path := obj["spec"].(map[string]interface{})["rules"].([]interface{})[0].(map[string]interface{})["matches"].([]interface{})[0].(map[string]interface{})["path"].(map[string]interface{})
+	assert.Equal(t, "PathPrefix", path["type"], "LLM 'Prefix' should be corrected to 'PathPrefix'")
+	assert.Equal(t, "/api", path["value"], "path value should be preserved")
+}
+
+func TestFixHTTPRoutePathTypes_AlreadyPathPrefix(t *testing.T) {
+	input := `{"spec":{"rules":[{"matches":[{"path":{"type":"PathPrefix","value":"/api"}}]}]}}`
+	output := fixHTTPRoutePathTypes([]byte(input))
+	assert.JSONEq(t, input, string(output), "already-correct PathPrefix should be unchanged")
+}
+
+func TestFixHTTPRoutePathTypes_ExactTypeUntouched(t *testing.T) {
+	input := `{"spec":{"rules":[{"matches":[{"path":{"type":"Exact","value":"/ping"}}]}]}}`
+	output := fixHTTPRoutePathTypes([]byte(input))
+	assert.JSONEq(t, input, string(output), "Exact path type should not be modified")
+}
+
+func TestFixHTTPRoutePathTypes_MultipleRulesAndMatches(t *testing.T) {
+	input := `{"spec":{"rules":[{"matches":[{"path":{"type":"Prefix","value":"/a"}},{"path":{"type":"Exact","value":"/b"}}]},{"matches":[{"path":{"type":"Prefix","value":"/c"}}]}]}}`
+	output := fixHTTPRoutePathTypes([]byte(input))
+	var obj map[string]interface{}
+	require.NoError(t, json.Unmarshal(output, &obj))
+	rules := obj["spec"].(map[string]interface{})["rules"].([]interface{})
+	// rule[0] match[0]: Prefix → PathPrefix
+	m00 := rules[0].(map[string]interface{})["matches"].([]interface{})[0].(map[string]interface{})["path"].(map[string]interface{})
+	assert.Equal(t, "PathPrefix", m00["type"])
+	// rule[0] match[1]: Exact → unchanged
+	m01 := rules[0].(map[string]interface{})["matches"].([]interface{})[1].(map[string]interface{})["path"].(map[string]interface{})
+	assert.Equal(t, "Exact", m01["type"])
+	// rule[1] match[0]: Prefix → PathPrefix
+	m10 := rules[1].(map[string]interface{})["matches"].([]interface{})[0].(map[string]interface{})["path"].(map[string]interface{})
+	assert.Equal(t, "PathPrefix", m10["type"])
+}
+
+func TestFixHTTPRoutePathTypes_InvalidJSONPassthrough(t *testing.T) {
+	input := []byte(`not-json`)
+	output := fixHTTPRoutePathTypes(input)
+	assert.Equal(t, input, output, "invalid JSON should be returned unchanged")
+}
+
+// ---------------------------------------------------------------------------
+// fixInferencePoolSpec unit tests
+// ---------------------------------------------------------------------------
+
+func TestFixInferencePoolSpec_TargetPortNumberMigrated(t *testing.T) {
+	input := `{"spec":{"targetPortNumber":8080,"selector":{"matchLabels":{"app":"model"}},"endpointPickerRef":{"kind":"Service","name":"epp"}}}`
+	output := fixInferencePoolSpec([]byte(input))
+	var obj map[string]interface{}
+	require.NoError(t, json.Unmarshal(output, &obj))
+	spec := obj["spec"].(map[string]interface{})
+	assert.Nil(t, spec["targetPortNumber"], "targetPortNumber should be removed")
+	targetPorts, ok := spec["targetPorts"].([]interface{})
+	require.True(t, ok, "targetPorts should be set")
+	require.Len(t, targetPorts, 1)
+	assert.Equal(t, float64(8080), targetPorts[0].(map[string]interface{})["number"])
+}
+
+func TestFixInferencePoolSpec_FlatSelectorWrapped(t *testing.T) {
+	input := `{"spec":{"targetPorts":[{"number":8000}],"selector":{"app":"my-model"},"endpointPickerRef":{"kind":"Service","name":"epp"}}}`
+	output := fixInferencePoolSpec([]byte(input))
+	var obj map[string]interface{}
+	require.NoError(t, json.Unmarshal(output, &obj))
+	sel := obj["spec"].(map[string]interface{})["selector"].(map[string]interface{})
+	ml, ok := sel["matchLabels"].(map[string]interface{})
+	require.True(t, ok, "flat selector should be wrapped under matchLabels")
+	assert.Equal(t, "my-model", ml["app"])
+}
+
+func TestFixInferencePoolSpec_AlreadyMatchLabelsSelectorUnchanged(t *testing.T) {
+	input := `{"spec":{"targetPorts":[{"number":8000}],"selector":{"matchLabels":{"app":"x"}},"endpointPickerRef":{"kind":"Service","name":"epp"}}}`
+	output := fixInferencePoolSpec([]byte(input))
+	assert.JSONEq(t, input, string(output), "already-correct selector should not be double-wrapped")
+}
+
+func TestFixInferencePoolSpec_MissingEndpointPickerRefAdded(t *testing.T) {
+	input := `{"spec":{"targetPorts":[{"number":8000}],"selector":{"matchLabels":{"app":"x"}}}}`
+	output := fixInferencePoolSpec([]byte(input))
+	var obj map[string]interface{}
+	require.NoError(t, json.Unmarshal(output, &obj))
+	epr := obj["spec"].(map[string]interface{})["endpointPickerRef"].(map[string]interface{})
+	assert.Equal(t, "Service", epr["kind"])
+	assert.Equal(t, "example-model-epp", epr["name"])
+	assert.Equal(t, "FailClose", epr["failureMode"])
+}
+
+func TestFixInferencePoolSpec_ExistingEndpointPickerRefPreserved(t *testing.T) {
+	input := `{"spec":{"targetPorts":[{"number":8000}],"selector":{"matchLabels":{"app":"x"}},"endpointPickerRef":{"kind":"Service","name":"my-real-epp"}}}`
+	output := fixInferencePoolSpec([]byte(input))
+	var obj map[string]interface{}
+	require.NoError(t, json.Unmarshal(output, &obj))
+	epr := obj["spec"].(map[string]interface{})["endpointPickerRef"].(map[string]interface{})
+	assert.Equal(t, "my-real-epp", epr["name"], "user-provided endpointPickerRef.name should not be overwritten")
+}
+
+func TestFixInferencePoolSpec_MissingTargetPortsAdded(t *testing.T) {
+	input := `{"spec":{"selector":{"matchLabels":{"app":"x"}},"endpointPickerRef":{"kind":"Service","name":"epp"}}}`
+	output := fixInferencePoolSpec([]byte(input))
+	var obj map[string]interface{}
+	require.NoError(t, json.Unmarshal(output, &obj))
+	targetPorts, ok := obj["spec"].(map[string]interface{})["targetPorts"].([]interface{})
+	require.True(t, ok)
+	assert.Equal(t, float64(8000), targetPorts[0].(map[string]interface{})["number"])
+}
+
+func TestFixInferencePoolSpec_InvalidJSONPassthrough(t *testing.T) {
+	input := []byte(`not-json`)
+	output := fixInferencePoolSpec(input)
+	assert.Equal(t, input, output, "invalid JSON should be returned unchanged")
+}
+
+// ---------------------------------------------------------------------------
+// inferGroupFromKind unit tests
+// ---------------------------------------------------------------------------
+
+func TestInferGroupFromKind(t *testing.T) {
+	tests := []struct {
+		name                  string
+		kind                  string
+		isGatewayAPIEnabled   bool
+		isInferenceAPIEnabled bool
+		expectedGroup         string
+	}{
+		{
+			name:          "security kind inferred without any flags",
+			kind:          "AuthorizationPolicy",
+			expectedGroup: "security.istio.io",
+		},
+		{
+			name:          "networking-only kind inferred when GW API disabled",
+			kind:          "VirtualService",
+			expectedGroup: "networking.istio.io",
+		},
+		{
+			name:                "networking-only kind inferred when GW API enabled",
+			kind:                "VirtualService",
+			isGatewayAPIEnabled: true,
+			expectedGroup:       "networking.istio.io",
+		},
+		{
+			name:                "Gateway is ambiguous when GW API enabled",
+			kind:                "Gateway",
+			isGatewayAPIEnabled: true,
+			expectedGroup:       "",
+		},
+		{
+			name:                "Gateway infers networking.istio.io when GW API disabled",
+			kind:                "Gateway",
+			isGatewayAPIEnabled: false,
+			expectedGroup:       "networking.istio.io",
+		},
+		{
+			name:                  "InferencePool inferred when inference API enabled",
+			kind:                  "InferencePool",
+			isInferenceAPIEnabled: true,
+			expectedGroup:         "inference.networking.k8s.io",
+		},
+		{
+			name:                  "InferencePool returns empty when inference API disabled",
+			kind:                  "InferencePool",
+			isInferenceAPIEnabled: false,
+			expectedGroup:         "",
+		},
+		{
+			name:                "HTTPRoute inferred as gateway API when enabled",
+			kind:                "HTTPRoute",
+			isGatewayAPIEnabled: true,
+			expectedGroup:       "gateway.networking.k8s.io",
+		},
+		{
+			name:                "HTTPRoute returns empty when GW API disabled",
+			kind:                "HTTPRoute",
+			isGatewayAPIEnabled: false,
+			expectedGroup:       "",
+		},
+		{
+			name:          "unknown kind returns empty",
+			kind:          "NoSuchKind",
+			expectedGroup: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := inferGroupFromKind(tt.kind, tt.isGatewayAPIEnabled, tt.isInferenceAPIEnabled)
+			assert.Equal(t, tt.expectedGroup, got)
+		})
+	}
 }


### PR DESCRIPTION
### Describe the change

- two bug fixes (endpointPickerRef.name inconsistency between fixInferencePoolSpec and buildResourceTemplate, and a variadic signature removed from defaultIstioConfigCriteria), 
- Rename of all gwEnabled/inferenceEnabled/enableGatewayAPI/enableInferenceAPI identifiers to the clearer isGatewayAPIEnabled/isInferenceAPIEnabled convention across 4 files
- New unit tests covering fixHTTPRoutePathTypes, fixInferencePoolSpec, inferGroupFromKind, and a regression test asserting that IstioList without a service filter returns all Gateways (not just those referenced by VirtualServices).

### Steps to test the PR

Recommendations for how to test this PR. Reminder that each PR should also include a "Test" label.

### Automation testing

If applicable, explain the case scencarios covered by **unit / integration / e2e** tests created for this PR.

### Issue reference

If this PR is related to a github issue, please link it here ([more info](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue))
